### PR TITLE
Fix: getCollection() Collection can be stuck with an empty collection, if getCollection() is called too quickly

### DIFF
--- a/src/lib/coreConnection.ts
+++ b/src/lib/coreConnection.ts
@@ -305,11 +305,11 @@ export class CoreConnection extends EventEmitter {
 		return this.callMethod(P.methods.getPeripheralDevice)
 	}
 	getCollection (collectionName: string): Collection {
-		const that = this
-		
+		const collections = this.ddp.ddpClient.collections
+
 		let c: Collection = {
 			find (selector?: any): Array<CollectionObj> {
-				const collection = that.ddp.ddpClient.collections[collectionName] || {}
+				const collection = collections[collectionName] || {}
 				if (_.isUndefined(selector)) {
 					return _.values(collection)
 				} else if (_.isFunction(selector)) {

--- a/src/lib/coreConnection.ts
+++ b/src/lib/coreConnection.ts
@@ -305,10 +305,11 @@ export class CoreConnection extends EventEmitter {
 		return this.callMethod(P.methods.getPeripheralDevice)
 	}
 	getCollection (collectionName: string): Collection {
-		let collection = this.ddp.ddpClient.collections[collectionName] || {}
-
+		const that = this
+		
 		let c: Collection = {
 			find (selector?: any): Array<CollectionObj> {
+				const collection = that.ddp.ddpClient.collections[collectionName] || {}
 				if (_.isUndefined(selector)) {
 					return _.values(collection)
 				} else if (_.isFunction(selector)) {

--- a/src/lib/corePeripherals.ts
+++ b/src/lib/corePeripherals.ts
@@ -6,19 +6,25 @@ export namespace PeripheralDeviceAPI {
 
 export enum StatusCode {
 
-	UNKNOWN = 0, 		// Status unknown
-	GOOD = 1, 			// All good and green
-	WARNING_MINOR = 2,	// Everything is not OK, operation is not affected
-	WARNING_MAJOR = 3, 	// Everything is not OK, operation might be affected
-	BAD = 4, 			// Operation affected, possible to recover
-	FATAL = 5			// Operation affected, not possible to recover without manual interference
+	/** Unknown status, could be due to parent device connected etc.. */
+	UNKNOWN = 0,
+	/** All good and green */
+	GOOD = 1,
+	/** Everything is not OK, but normal operation should not be affected. An optional/backup service might be offline, etc. */
+	WARNING_MINOR = 2,
+	/** Everything is not OK, operation might be affected. Like when having switched to a backup, or have taken action to fix an error. */
+	WARNING_MAJOR = 3,
+	/** Not good. Operation is affected. Will be able to recover on it's own when the situation changes. */
+	BAD = 4,
+	/** Not good. Operation is affected. Will NOT be able to to recover from this, manual intervention will be required. */
+	FATAL = 5
 }
 
 export interface StatusObject {
 	statusCode: StatusCode,
 	messages?: Array<string>
 }
-// Note The actual type of a device is determined by the Category, Type and SubType
+// Note: The definite type of a device is determined by the Category, Type and SubType
 export enum DeviceCategory {
 	INGEST = 'ingest',
 	PLAYOUT = 'playout',


### PR DESCRIPTION
`getCollection()` has an unexpected behavior that appears when the collection in question hasn't yet been registered by the ddpClient. If that's the case, the `getCollection()` will fall back to an empty object. That empty object is then cached forever in the Collection result, and subsequent `find()` and `findOne()` requests will always fail. This causes the Core-Integration collection to behave in a different manner from a Meteor collection.

This changes that behavior in that `collection.find()` will always try to get the collection from ddpClient on each execution, only falling back to an empty object if not found.