### PR TITLE
Add iNewsdevice

### DIFF
--- a/src/lib/corePeripherals.ts
+++ b/src/lib/corePeripherals.ts
@@ -39,6 +39,7 @@ export enum DeviceType {
 	// Ingest devices:
 	MOS 			= 'mos',
 	SPREADSHEET 	= 'spreadsheet',
+	INEWS			= 'inews',
 	// Playout devices:
 	PLAYOUT 		= 'playout',
 	// Media-manager devices:


### PR DESCRIPTION
Adds the iNews device to the DeviceType enum.

In future this will hopefully not be needed, but there are significant problems to solve before generic ingest gateways can attach to Sofie without Sofie having any knowledge of the device.
