### PR TITLE
fix: Add clearMediaObjectCollection method

### DIFF
--- a/src/lib/corePeripherals.ts
+++ b/src/lib/corePeripherals.ts
@@ -139,8 +139,9 @@ export enum methods {
 
 	'resyncRundown'				= 'peripheralDevice.mos.roResync',
 
-	'getMediaObjectRevisions' 	= 'peripheralDevice.mediaScanner.getMediaObjectRevisions',
-	'updateMediaObject' 		= 'peripheralDevice.mediaScanner.updateMediaObject',
+	'getMediaObjectRevisions'		= 'peripheralDevice.mediaScanner.getMediaObjectRevisions',
+	'updateMediaObject' 			= 'peripheralDevice.mediaScanner.updateMediaObject',
+	'clearMediaObjectCollection' 	= 'peripheralDevice.mediaScanner.clearMediaObjectCollection',
 
 	'getMediaWorkFlowRevisions' 	= 'peripheralDevice.mediaManager.getMediaWorkFlowRevisions',
 	'updateMediaWorkFlow' 			= 'peripheralDevice.mediaManager.updateMediaWorkFlow',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds the `clearMediaObjectCollection` method to the list of `PeripheralDeviceAPI` methods. This method is added to Core in the following PR:
https://github.com/nrkno/tv-automation-server-core/pull/316


