### PR TITLE
fix: reduced amount of watchdogs calls

### DIFF
--- a/src/lib/coreConnection.ts
+++ b/src/lib/coreConnection.ts
@@ -151,6 +151,9 @@ export class CoreConnection extends EventEmitter {
 					// this.emit('disconnected')
 					if (this._watchDog) this._watchDog.removeCheck(() => this._watchDogCheck())
 				})
+				this._ddp.on('message', () => {
+					if (this._watchDog) this._watchDog.receivedData()
+				})
 				resolve()
 			}).then(() => {
 				return this._ddp.createClient()


### PR DESCRIPTION
Answering ping commands from the gateway can slow down core during playout related tasks. Instead of sending pings every 60s we now only send pings every 60s after receiving data from core. This makes it less likely that the gateway can disturb playout performance.