### PR TITLE
Add dataRundownGet and dataSegmentGet methods

### DIFF
--- a/src/lib/corePeripherals.ts
+++ b/src/lib/corePeripherals.ts
@@ -127,6 +127,7 @@ export enum methods {
 	'mosRoReadyToAir' 	= 'peripheralDevice.mos.roReadyToAir',
 	'mosRoFullStory' 	= 'peripheralDevice.mos.roFullStory',
 
+	'dataRundownList'	= 'peripheralDevice.rundown.rundownList',
 	'dataRundownGet'	= 'peripheralDevice.rundown.rundownGet',
 	'dataRundownDelete'	= 'peripheralDevice.rundown.rundownDelete',
 	'dataRundownCreate'	= 'peripheralDevice.rundown.rundownCreate',

--- a/src/lib/corePeripherals.ts
+++ b/src/lib/corePeripherals.ts
@@ -127,9 +127,11 @@ export enum methods {
 	'mosRoReadyToAir' 	= 'peripheralDevice.mos.roReadyToAir',
 	'mosRoFullStory' 	= 'peripheralDevice.mos.roFullStory',
 
+	'dataRundownGet'	= 'peripheralDevice.rundown.rundownGet',
 	'dataRundownDelete'	= 'peripheralDevice.rundown.rundownDelete',
 	'dataRundownCreate'	= 'peripheralDevice.rundown.rundownCreate',
 	'dataRundownUpdate'	= 'peripheralDevice.rundown.rundownUpdate',
+	'dataSegmentGet'	= 'peripheralDevice.rundown.segmentGet',
 	'dataSegmentDelete'	= 'peripheralDevice.rundown.segmentDelete',
 	'dataSegmentCreate'	= 'peripheralDevice.rundown.segmentCreate',
 	'dataSegmentUpdate'	= 'peripheralDevice.rundown.segmentUpdate',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the peripheral device methods `dataRundownGet` and `dataSegmentGet` which return an Ingest Rundown / Ingest Segment from core, referenced by external Id.